### PR TITLE
Wrap setReadyStatus with imageready

### DIFF
--- a/js/adapt-hotgrid.js
+++ b/js/adapt-hotgrid.js
@@ -33,7 +33,9 @@ define(function(require) {
 
         postRender: function() {
             this.setupGrid();
-            this.setReadyStatus();
+            this.$('.hotgrid-widget').imageready(_.bind(function() {
+                this.setReadyStatus();
+            }, this));
         },
 
         resizeControl: function() {


### PR DESCRIPTION
On iPad: 
With Trickle set on an article containing Hot Grid, scrolling too quickly down the page would prevent all Hot Grid images from loading. Seems Trickle was calculating page height before the Hot Grid component could expand to encompass the loading images. The result was the Hot Grid was being cut-off by Trickle. This could be alleviated by scrolling back up the page and allowing the Hot Grid to reload.

This inconvenience was eliminated by using imageready with "_setReadyStatus()".