### PR TITLE
Refactored column setup, changed <a> to <button>

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Hotgrid automatically switches to 2 columns in mobile mode for the best user exp
 
 
 ----------------------------
-**Version number:**  2.0
+**Version number:**  3.0
 **Framework versions:**  2.0     
 **Author / maintainer:**   
 **Accessibility support:** WAI AA   

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Hotgrid has a dynamic layout system. If you have 5 items but set the columns to 
 ## Limitations
  
 Hotgrid automatically switches to 2 columns in mobile mode for the best user experience however this can be overridden in the css. 
-
+Version 2.1.0 contains two changes that could potentially break if users update from previous versions. The first, the introduction of `font-size: 0;` on the item container div, may cause item titles not to appear. Applying a font size to the titles will resolve this issue. The second, changing clickable elements from `<a>` to `<button>`, may cause display errors if the `<a>` tag has been directly targeted in the JS or LESS files. To resolve, target the `<button>` tag instead.
 
 ----------------------------
 **Version number:**  2.1.0

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Hotgrid automatically switches to 2 columns in mobile mode for the best user exp
 
 
 ----------------------------
-**Version number:**  3.0
+**Version number:**  2.1.0
 **Framework versions:**  2.0     
 **Author / maintainer:**   
 **Accessibility support:** WAI AA   

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
     "name": "adapt-hotgrid",
     "repository": "git://github.com/cgkineo/adapt-hotgrid",
     "framework": "^2.0.0",
-    "version": "3.0.0",
+    "version": "2.1.0",
     "homepage": "https://github.com/cgkineo/adapt-hotgrid",
     "issues": "https://github.com/cgkineo/adapt-hotgrid/issues/",
     "displayName": "Hotgrid",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
     "name": "adapt-hotgrid",
     "repository": "git://github.com/cgkineo/adapt-hotgrid",
     "framework": "^2.0.0",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "homepage": "https://github.com/cgkineo/adapt-hotgrid",
     "issues": "https://github.com/cgkineo/adapt-hotgrid/issues/",
     "displayName": "Hotgrid",

--- a/js/adapt-hotgrid.js
+++ b/js/adapt-hotgrid.js
@@ -36,7 +36,7 @@ define(function(require) {
         },
 
         postRender: function() {
-            this.setupGrid();
+            this.setUpColumns();
             this.$('.hotgrid-widget').imageready(_.bind(function() {
                 this.setReadyStatus();
             }, this));
@@ -47,56 +47,13 @@ define(function(require) {
             this.render();
         },
 
-        setupGrid: function() {
-            if (this.model.get("_isDesktop")) {
-                var columns = this.model.get("_columns");
-                var itemWidth = 100 / columns;
-                this.$(".hotgrid-grid-item").css({
-                    width: itemWidth + "%"
-                });
-                this.setItemlayout()
-            }
-        },
+        setUpColumns: function() {
+            var columns = this.model.get('_columns');
 
-        setItemlayout: function() {
-            var columns = this.model.get("_columns");
-            var itemLength = this.model.get("_items").length;
-            var $items = this.$(".hotgrid-grid-item");
-            var itemRemainder = itemLength % columns;
-            if (itemRemainder !== 0) {
-                if (itemRemainder === 1) {
-                    var index = itemLength - 1;
-                    var $item = $items.eq(index);
-                    this.centerItem($item);
-                } else {
-                    var itemToAlignIndex = itemLength - itemRemainder;
-                    var $item = $items.eq(itemToAlignIndex);
-                    this.alignItem($item, itemRemainder);
-                }
-            }
-        },
+            if (!columns) return;
 
-        centerItem: function(item) {
-            item.css({
-                float: "none",
-                margin: "auto"
-            });
-        },
-
-        alignItem: function(item, itemsToAlign) {
-            var columns = this.model.get("_columns");
-            var itemWidth = 100 / columns;
-
-            if (Adapt.config.get('_defaultDirection') == 'rtl') {
-                var marginRight = itemWidth / 2;
-                item.css({
-                    marginRight: marginRight + "%"
-                });
-            } else {
-                var marginLeft = itemWidth / 2;
-                item.css({
-                    marginLeft: marginLeft + "%"
-                });
+            if (Adapt.device.screenSize === 'large') {
+                this.$('.hotgrid-grid-item').css('width', (100 / columns) + '%');
             }
         },
 

--- a/js/adapt-hotgrid.js
+++ b/js/adapt-hotgrid.js
@@ -50,9 +50,7 @@ define(function(require) {
         setUpColumns: function() {
             var columns = this.model.get('_columns');
 
-            if (!columns) return;
-
-            if (Adapt.device.screenSize === 'large') {
+           if (columns && Adapt.device.screenSize === 'large') {
                 this.$('.hotgrid-grid-item').css('width', (100 / columns) + '%');
             }
         },

--- a/less/hotgrid.less
+++ b/less/hotgrid.less
@@ -1,21 +1,20 @@
 .hotgrid-component {
 	.hotgrid-widget {
+		font-size: 0;
 		position: relative;
+		text-align: center;
 	}
 
 	.hotgrid-grid-item {
-		float: left;
+		display: inline-block;
 		text-align: center;
+		vertical-align: top;
 		width: 50%;
 
 		&.visited {
 			.hotgrid-item-states-image {
 				.item-states-image.visited;
 			}
-		}
-
-		.dir-rtl & {
-			float: right;
 		}
 	}
 
@@ -39,6 +38,10 @@
 		@media all and (max-width:(@device-width-medium - 1)) {
 			margin: 5px;
 		}
+	}
+	
+	.hotgrid-item-title {
+		font-size: @body-text-font-size;
 	}
 }
 

--- a/less/hotgrid.less
+++ b/less/hotgrid.less
@@ -1,5 +1,6 @@
 .hotgrid-component {
 	.hotgrid-widget {
+		// Font size set to 0 so there's no gap between items
 		font-size: 0;
 		position: relative;
 		text-align: center;

--- a/templates/hotgrid.hbs
+++ b/templates/hotgrid.hbs
@@ -4,18 +4,24 @@
 
         <div class="hotgrid-grid">
             <div class="hotgrid-grid-inner clearfix">
+                
                 {{#each _items}}
                 <div class="hotgrid-grid-item {{#if visited}}visited{{/if}}">
-                    <a href="#" class="hotgrid-item-image hotgrid-item-states-{{#if _graphic.hasImageStates}}image{{else}}css{{/if}}" role="button" aria-label="{{#if _graphic.title}}{{_graphic.title}}.{{/if}}{{#if _graphic.alt}} {{_graphic.alt}}.{{/if}}{{#if visited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
+                    <button class="base hotgrid-item-image hotgrid-item-states-{{#if _graphic.hasImageStates}}image{{else}}css{{/if}}" role="button" aria-label="{{#if _graphic.title}}{{_graphic.title}}.{{/if}}{{#if _graphic.alt}} {{_graphic.alt}}.{{/if}}{{#if visited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
                         <img src="{{_graphic.src}}"/>
-                    {{#if _graphic.hasImageStates}} 
-                            <img src="{{_graphic.srcHover}}" class="hotgrid-item-image-hover"/>
-                            <img src="{{_graphic.srcVisited}}" class="hotgrid-item-image-visited"/>                                          
+                        
+                        {{#if _graphic.hasImageStates}} 
+                        <img src="{{_graphic.srcHover}}" class="hotgrid-item-image-hover"/>
+                        <img src="{{_graphic.srcVisited}}" class="hotgrid-item-image-visited"/>                                          
                         {{/if}}
-                        </a>
-                        <div class="hotgrid-item-title">{{_graphic.title}}</div>   
+                        
+                    </button>
+                    
+                    <div class="hotgrid-item-title">{{_graphic.title}}</div>   
+                    
                 </div>
                 {{/each}}
+                
             </div>
         </div>
 


### PR DESCRIPTION
Reduced JS code to setup item widths based upon '_columns' value.

Amended LESS to use 'display: inline-block' style instead.

Updated template file to use `<button>` tag instead of `<a>` tag for OS Voiceover compatibility.

Bumped bower.json and readMe version to 3 as this change has the potential to introduce breaking changes.
