### PR TITLE
issue/48 prevent bad event trigger on ios

### DIFF
--- a/js/hotgridPopupView.js
+++ b/js/hotgridPopupView.js
@@ -13,6 +13,7 @@ define([
     },
 
     initialize: function() {
+      // Debounce required as a second (bad) click event is dispatched on iOS causing a jump of two items.
       this.onControlClick = _.debounce(this.onControlClick.bind(this), 100);
       this.listenToOnce(Adapt, 'notify:opened', this.onOpened);
       this.listenTo(this.model.get('_children'), {

--- a/js/hotgridPopupView.js
+++ b/js/hotgridPopupView.js
@@ -13,6 +13,7 @@ define([
     },
 
     initialize: function() {
+      this.onControlClick = _.debounce(this.onControlClick.bind(this), 100);
       this.listenToOnce(Adapt, 'notify:opened', this.onOpened);
       this.listenTo(this.model.get('_children'), {
         'change:_isActive': this.onItemsActiveChange,


### PR DESCRIPTION
#48 
* debounced onControlClick to stop view responding to a bad ios click being triggered by the browser