### PR TITLE
Set popup count line height

### DIFF
--- a/less/hotgridPopup.less
+++ b/less/hotgridPopup.less
@@ -29,6 +29,7 @@
 
   &__count {
     padding: @icon-padding;
+    line-height: 1;
   }
 
   &__controls.is-disabled {


### PR DESCRIPTION
Resolves https://github.com/cgkineo/adapt-hotgrid/issues/74

* Set line height of the hotgrid popup count area to 1 