### PR TITLE
Prevent toggleHidden from targeting child elements causing images without 'alt' to be read by screen reader

### DIFF
--- a/js/hotgridPopupView.js
+++ b/js/hotgridPopupView.js
@@ -55,8 +55,8 @@ define([
     },
 
     handleTabs: function() {
-      Adapt.a11y.toggleHidden(this.$('.hotgrid-popup__item:not(.is-active) *'), true);
-      Adapt.a11y.toggleHidden(this.$('.hotgrid-popup__item.is-active *'), false);
+      Adapt.a11y.toggleHidden(this.$('.hotgrid-popup__item:not(.is-active)'), true);
+      Adapt.a11y.toggleHidden(this.$('.hotgrid-popup__item.is-active'), false);
     },
 
     onItemsActiveChange: function(item, _isActive) {


### PR DESCRIPTION
Resolves https://github.com/cgkineo/adapt-hotgrid/issues/76