### PR TITLE
Update: Remove visibility: hidden from disabled popup paging buttons (fixes #86)

### DIFF
--- a/js/hotgridPopupView.js
+++ b/js/hotgridPopupView.js
@@ -41,8 +41,8 @@ define([
         .toggleClass('first', !shouldEnableBack)
         .toggleClass('last', !shouldEnableNext);
 
-      Adapt.a11y.toggleAccessibleEnabled($controls.filter('.back'), shouldEnableBack);
-      Adapt.a11y.toggleAccessibleEnabled($controls.filter('.next'), shouldEnableNext);
+      Adapt.a11y.toggleEnabled($controls.filter('.back'), shouldEnableBack);
+      Adapt.a11y.toggleEnabled($controls.filter('.next'), shouldEnableNext);
     },
 
     updatePageCount: function() {

--- a/js/hotgridPopupView.js
+++ b/js/hotgridPopupView.js
@@ -3,7 +3,7 @@ define([
 ], function(Adapt) {
   'use strict';
 
-  var HotgridPopupView = Backbone.View.extend({
+  const HotgridPopupView = Backbone.View.extend({
 
     className: 'hotgrid-popup',
 
@@ -30,12 +30,12 @@ define([
     },
 
     applyNavigationClasses: function (index) {
-      var itemCount = this.model.get('_items').length;
-      var canCycleThroughPagination = this.model.get('_canCycleThroughPagination');
+      const itemCount = this.model.get('_items').length;
+      const canCycleThroughPagination = this.model.get('_canCycleThroughPagination');
 
-      var shouldEnableBack = index > 0 || canCycleThroughPagination;
-      var shouldEnableNext = index < itemCount - 1 || canCycleThroughPagination;
-      var $controls = this.$('.hotgrid-popup__controls');
+      const shouldEnableBack = index > 0 || canCycleThroughPagination;
+      const shouldEnableNext = index < itemCount - 1 || canCycleThroughPagination;
+      const $controls = this.$('.hotgrid-popup__controls');
 
       this.$('hotgrid-popup__nav')
         .toggleClass('first', !shouldEnableBack)
@@ -46,10 +46,10 @@ define([
     },
 
     updatePageCount: function() {
-      var template = Adapt.course.get('_globals')._components._hotgrid.popupPagination || '{{itemNumber}} / {{totalItems}}';
-      var labelText = Handlebars.compile(template || '')({
-          itemNumber: this.model.getActiveItem().get('_index') + 1,
-          totalItems: this.model.get('_items').length
+      const template = Adapt.course.get('_globals')._components._hotgrid.popupPagination || '{{itemNumber}} / {{totalItems}}';
+      const labelText = Handlebars.compile(template || '')({
+        itemNumber: this.model.getActiveItem().get('_index') + 1,
+        totalItems: this.model.get('_items').length
       });
       this.$('.hotgrid-popup__count').html(labelText);
     },
@@ -62,7 +62,7 @@ define([
     onItemsActiveChange: function(item, _isActive) {
       if (!_isActive) return;
 
-      var index = item.get('_index');
+      const index = item.get('_index');
       this.updatePageCount();
       this.applyItemClasses(index);
       this.handleTabs();
@@ -71,9 +71,9 @@ define([
 
     applyItemClasses: function(index) {
       this.$('.hotgrid-popup__item[data-index="' + index + '"]').addClass('is-active').removeAttr('aria-hidden');
-      this.$('.hotgrid-popup__item[data-index="' + index + '"] .hotgrid-popup__item-title').attr("id", "notify-heading");
+      this.$('.hotgrid-popup__item[data-index="' + index + '"] .hotgrid-popup__item-title').attr('id', 'notify-heading');
       this.$('.hotgrid-popup__item:not([data-index="' + index + '"])').removeClass('is-active').attr('aria-hidden', 'true');
-      this.$('.hotgrid-popup__item:not([data-index="' + index + '"]) .hotgrid-popup__item-title').removeAttr("id");
+      this.$('.hotgrid-popup__item:not([data-index="' + index + '"]) .hotgrid-popup__item-title').removeAttr('id');
     },
 
     handleFocus: function(index) {
@@ -90,9 +90,9 @@ define([
     },
 
     render: function() {
-      var data = this.model.toJSON();
+      const data = this.model.toJSON();
       data.view = this;
-      var template = Handlebars.templates['hotgridPopup'];
+      const template = Handlebars.templates['hotgridPopup'];
       this.$el.html(template(data));
     },
 
@@ -101,8 +101,8 @@ define([
     },
 
     onControlClick: function(event) {
-      var direction = $(event.currentTarget).hasClass('back') ? 'back' : 'next';
-      var index = this.getNextIndex(direction);
+      const direction = $(event.currentTarget).hasClass('back') ? 'back' : 'next';
+      const index = this.getNextIndex(direction);
 
       if (index !== -1) {
         this.setItemState(index);
@@ -110,8 +110,8 @@ define([
     },
 
     getNextIndex: function(direction) {
-      var index = this.model.getActiveItem().get('_index');
-      var lastIndex = this.model.get('_items').length - 1;
+      let index = this.model.getActiveItem().get('_index');
+      const lastIndex = this.model.get('_items').length - 1;
 
       switch (direction) {
         case 'back':
@@ -128,7 +128,7 @@ define([
     setItemState: function(index) {
       this.model.getActiveItem().toggleActive();
 
-      var nextItem = this.model.getItem(index);
+      const nextItem = this.model.getItem(index);
       nextItem.toggleActive();
       nextItem.toggleVisited(true);
     }

--- a/js/hotgridView.js
+++ b/js/hotgridView.js
@@ -4,7 +4,7 @@ define([
   './hotgridPopupView'
 ], function(Adapt, ComponentView, HotgridPopupView) {
 
-  var HotgridView = ComponentView.extend({
+  const HotgridView = ComponentView.extend({
 
     events: {
       'click .js-hotgrid-item-click': 'onItemClicked'
@@ -45,12 +45,12 @@ define([
         this.model.set('_isDesktop', true);
       } else {
         this.$el.addClass('is-mobile').removeClass('is-desktop');
-        this.model.set('_isDesktop', false)
+        this.model.set('_isDesktop', false);
       }
     },
 
     checkIfResetOnRevisit: function() {
-      var isResetOnRevisit = this.model.get('_isResetOnRevisit');
+      const isResetOnRevisit = this.model.get('_isResetOnRevisit');
 
       // If reset is enabled set defaults
       if (isResetOnRevisit) this.model.reset(isResetOnRevisit);
@@ -71,7 +71,7 @@ define([
     },
 
     setUpColumns: function() {
-      var columns = this.model.get('_columns');
+      const columns = this.model.get('_columns');
 
       if (columns && Adapt.device.screenSize === 'large') {
         this.$('.hotgrid__item').css('width', (100 / columns) + '%');
@@ -83,20 +83,20 @@ define([
     },
 
     getItemElement: function(model) {
-      var index = model.get('_index');
+      const index = model.get('_index');
       return this.$('.hotgrid__item-btn').filter('[data-index="' + index + '"]');
     },
 
-    updateVisitedState:function(itemModel) {
-      var itemModels = itemModel ? [itemModel] : this.model.getChildren().models;
+    updateVisitedState: function(itemModel) {
+      const itemModels = itemModel ? [itemModel] : this.model.getChildren().models;
 
       _.each(itemModels, function(model) {
         if (!model.get('_isVisited')) return;
 
-        var $item = this.getItemElement(model);
+        const $item = this.getItemElement(model);
 
         // Append the word 'visited' to the item's aria-label
-        var visitedLabel = this.model.get('_globals')._accessibility._ariaLabels.visited + '.';
+        const visitedLabel = this.model.get('_globals')._accessibility._ariaLabels.visited + '.';
         $item.find('.aria-label').each(function(index, ariaLabel) {
           ariaLabel.innerHTML += ' ' + visitedLabel;
         });
@@ -113,7 +113,7 @@ define([
     onItemClicked: function(event) {
       if (event) event.preventDefault();
 
-      var item = this.model.getItem($(event.currentTarget).data('index'));
+      const item = this.model.getItem($(event.currentTarget).data('index'));
       item.toggleActive(true);
       item.toggleVisited(true);
 
@@ -134,7 +134,7 @@ define([
         _isCancellable: true,
         _showCloseButton: false,
         _classes: 'hotgrid ' + this.model.get('_classes')
-      })
+      });
 
       this.listenToOnce(Adapt, {
         'popup:closed': this.onPopupClosed

--- a/less/hotgridPopup.less
+++ b/less/hotgridPopup.less
@@ -32,10 +32,6 @@
     line-height: 1;
   }
 
-  &__controls.is-disabled {
-    visibility: hidden;
-  }
-
   // Pop up item
   // --------------------------------------------------
   &__item-image-container {


### PR DESCRIPTION
Fixes #86

### Update
* Removes 'visibility: hidden' from Hotgrid popup disabled paging buttons

### Testing
1. Add a Hotgrid component to a course.
1. Click on an item to open the Notify popup.
1. The disabled buttons should be visible.

Requires https://github.com/adaptlearning/adapt-contrib-core/pull/221