### PR TITLE
Fix: Fix popup close button aria-label (fixes #102)

### DIFF
--- a/templates/hotgridPopupToolbar.jsx
+++ b/templates/hotgridPopupToolbar.jsx
@@ -67,7 +67,7 @@ export default function HotgridPopupToolbar(props) {
 
       <button
         className="btn-icon hotgrid-popup__close"
-        aria-label={ariaLabels.onCloseClick}
+        aria-label={ariaLabels.closePopup}
         onClick={onCloseClick}
       >
         <span className="icon" aria-hidden="true" />


### PR DESCRIPTION
Fixes #102 

### Fix
* Changes the Hotgrid Notify close button's aria-label to the correct identifier
