### PR TITLE
Fix: aria-haspopup removed from hotgrid buttons (Fixes (#107))

### DIFF
--- a/templates/hotgrid.jsx
+++ b/templates/hotgrid.jsx
@@ -56,7 +56,6 @@ export default function Hotgrid(props) {
               ])}
               onClick={onItemClicked}
               data-index={_index}
-              aria-haspopup="dialog"
               >
 
                 <span className="aria-label" dangerouslySetInnerHTML={ itemAriaLabel(_index, _graphic, _isVisited) } />


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes (#107)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* aria-haspopup removed from hotgrid buttons (#107)

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Using Jaws, navigate to Hotgrid
2. Move between items using keyboard arrows
3. Open an item and close
4. Use arrows to move to a different item to check it's not just scrolling the page

aria-haspopup has some issues with various screen readers and is not fully compatible (https://www.digitala11y.com/aria-haspopup-properties/). Looking through github threads, this has been an issue for years and has not been resolved, best to remove entirely.


