### PR TITLE
Fix: Move popup toolbar below content for screen readers (fixes #109)

### DIFF
--- a/templates/hotgridPopup.jsx
+++ b/templates/hotgridPopup.jsx
@@ -23,8 +23,6 @@ export default function HotgridPopup(props) {
   return (
     <div className='hotgrid-popup__inner'>
 
-      <templates.hotgridPopupToolbar {...props} />
-
       {_items.map(({ title, body, _itemGraphic, _graphic, _classes, _isVisited, _isActive, _imageAlignment }, index) =>
         <div className={classes([
           'hotgrid-popup__item',
@@ -95,6 +93,8 @@ export default function HotgridPopup(props) {
 
         </div>
       )}
+
+      <templates.hotgridPopupToolbar {...props} />
 
     </div>
 


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes (#109) 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Fix: Move popup navigation below content for screen readers (#109)

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Navigate to hotgrid using screen reader
2. Open an item to check it focuses on content rather than popup toolbar

[//]: # (Mention any other dependencies)


