### PR TITLE
Fix: hotgrid popup toolbar count aria-hidden=true

### DIFF
--- a/templates/hotgridPopupToolbar.jsx
+++ b/templates/hotgridPopupToolbar.jsx
@@ -47,6 +47,7 @@ export default function HotgridPopupToolbar(props) {
         <div
           className="hotgrid-popup__count"
           dangerouslySetInnerHTML={{ __html: itemCount }}
+          aria-hidden="true"
         />
 
         <button


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes #111 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* hotgrid popup toolbar count aria-hidden=true (#111)

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Open a hotgrid item using a screen reader navigate through popup toolbar 
2. Ensure the popup count is not read out 



