### PR TITLE
Fix: Jaws highlight issue for close button (fixes #113)

### DIFF
--- a/templates/hotgridPopupToolbar.jsx
+++ b/templates/hotgridPopupToolbar.jsx
@@ -74,7 +74,7 @@ export default function HotgridPopupToolbar(props) {
       </button>
 
       {a11yConfig._options._isPopupWrapFocusEnabled &&
-      <a className="a11y-focusguard a11y-ignore a11y-ignore-focus" tabIndex="0" role="presentation">&nbsp;</a>
+      <a className="a11y-focusguard a11y-ignore a11y-ignore-focus" tabIndex="0" role="presentation"></a>
       }
 
     </div>


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes #113 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Jaws highlight issue for close button (fixes #113)

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Using Jaws (2023), open a hotgrid item and navigate to the close button
2. Check the highlight box of the button 

[//]: # (Mention any other dependencies)


