### PR TITLE
Fix: Item popup title missing ARIA heading role (fixes #120)

### DIFF
--- a/templates/hotgridPopup.jsx
+++ b/templates/hotgridPopup.jsx
@@ -46,6 +46,7 @@ export default function HotgridPopup(props) {
                   'hotgrid-popup__item-title',
                   _isActive && 'notify-heading'
                 ])}
+                role="heading"
                 aria-level={a11y.ariaLevel({ level: 'notify' })}
               >
                 <div


### PR DESCRIPTION
The popup title, `.hotgrid-popup__item-title` is read by a screen reader but it isn't announced as a 'heading' neither is the heading aria-level announced. 

The current implementation doesn't have a `role='heading'` assigned which is required for `aria-level `to read.

Fixes https://github.com/cgkineo/adapt-hotgrid/issues/120