### PR TITLE
Fix: Realign breakpoint for column layout to medium and above (fixes #122)

### DIFF
--- a/js/HotgridView.js
+++ b/js/HotgridView.js
@@ -40,7 +40,7 @@ class HotgridView extends ComponentView {
 
   setUpColumns() {
     const columns = this.model.get('_columns');
-    const columnWidth = columns && device.screenSize === 'large' ? 100 / columns : 100;
+    const columnWidth = columns && device.isScreenSizeMin('medium') ? 100 / columns : 100;
 
     this.model.set('_columnWidth', columnWidth);
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-hotgrid",
   "version": "4.3.9",
-  "framework": ">=5.22.4",
+  "framework": ">=5.31.2",
   "homepage": "https://github.com/cgkineo/adapt-hotgrid",
   "issues": "https://github.com/cgkineo/adapt-hotgrid/issues/",
   "component": "hotgrid",


### PR DESCRIPTION
fixes https://github.com/cgkineo/adapt-hotgrid/issues/122 

requires https://github.com/adaptlearning/adapt-contrib-core/pull/372

### Fix
- Moved breakpoint to medium from large
- FW version bumped inline with core code