### PR TITLE
Update: add generic .notify__btn-icon class (fixes #126)

### DIFF
--- a/less/hotgridPopup.less
+++ b/less/hotgridPopup.less
@@ -133,21 +133,6 @@
     padding-top: (@icon-size + (@icon-padding * 2)) + (@item-padding / 2);
   }
 
-  .btn-icon&__controls,
-  .btn-icon&__close {
-    margin: @btn-margin / 2;
-    padding: @btn-padding / 2;
-    background-color: @notify-icon;
-    color: @notify-icon-inverted;
-    border-radius: 50%;
-
-    .no-touch &:not(.is-disabled):not(.is-locked):hover {
-      background-color: @notify-icon-hover;
-      color: @notify-icon-inverted-hover;
-      .transition(background-color @duration ease-in, color @duration ease-in;);
-    }
-  }
-
   &__item-title {
     margin-bottom: @notify-title-margin;
     .notify-title;

--- a/templates/hotgridPopupToolbar.jsx
+++ b/templates/hotgridPopupToolbar.jsx
@@ -33,7 +33,7 @@ export default function HotgridPopupToolbar(props) {
 
         <button
           className={classes([
-            'btn-icon hotgrid-popup__controls back',
+            'btn-icon notify__btn-icon hotgrid-popup__controls back',
             !shouldEnableBack && 'is-disabled'
           ])}
           aria-label={backLabel}
@@ -52,7 +52,7 @@ export default function HotgridPopupToolbar(props) {
 
         <button
           className={classes([
-            'btn-icon hotgrid-popup__controls next',
+            'btn-icon notify__btn-icon hotgrid-popup__controls next',
             !shouldEnableNext && 'is-disabled'
           ])}
           aria-label={nextLabel}
@@ -67,7 +67,7 @@ export default function HotgridPopupToolbar(props) {
       }
 
       <button
-        className="btn-icon hotgrid-popup__close"
+        className="btn-icon notify__btn-icon hotgrid-popup__close"
         aria-label={ariaLabels.closePopup}
         onClick={onCloseClick}
       >


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-hotgrid/issues/126

- Apply `.notify__btn-icon` to popup icon buttons to inherit styles from [Vanilla notify.less](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/142b4fde60d638e280d04d691c63fbe62bd5abfe/less/core/notify.less#LL74C3-L86C4).

- Remove the duplicate styles from Hotgrid (these just repeat what's now inherited from Vanilla). 

This means the default Notify button icon style is set in one place but we still have plugin specific classes to target should you want to style these different - although there's good reason for keeping UI button styling consistent.

Ref: similar PR raised for Hotgraphic https://github.com/adaptlearning/adapt-contrib-hotgraphic/pull/276