### PR TITLE
Fix: compile title (fixes #124)

### DIFF
--- a/templates/hotgrid.jsx
+++ b/templates/hotgrid.jsx
@@ -1,6 +1,6 @@
 import Adapt from 'core/js/adapt';
 import React from 'react';
-import { templates, classes } from 'core/js/reactHelpers';
+import { templates, classes, compile } from 'core/js/reactHelpers';
 
 export default function Hotgrid(props) {
   const hotgridGlobals = Adapt.course.get('_globals')._components._hotgrid;
@@ -87,7 +87,7 @@ export default function Hotgrid(props) {
                   <span className="hotgrid__item-title" aria-hidden="true">
                     <span
                       className="hotgrid__item-title-inner"
-                      dangerouslySetInnerHTML={{ __html: _graphic.title }}
+                      dangerouslySetInnerHTML={{ __html: compile(_graphic.title) }}
                     />
                   </span>
                   }

--- a/templates/hotgridPopup.jsx
+++ b/templates/hotgridPopup.jsx
@@ -51,7 +51,7 @@ export default function HotgridPopup(props) {
               >
                 <div
                   className="hotgrid-popup__item-title-inner"
-                  dangerouslySetInnerHTML={{ __html: title }}
+                  dangerouslySetInnerHTML={{ __html: compile(title) }}
                 />
               </div>
               }


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-hotgrid/issues/124

To support [a11y_alt_text](https://github.com/adaptlearning/adapt-contrib-core/commit/a92c7ffdb431bdf126e080c009b3b9c324642755) helper tag.

## PR Test
Add `a11y_alt_text` helper to Hotgrid item `title` and item `_graphic` `title`.
e.g. `{{a11y_alt_text '$5bn' 'five billion dollars'}}`.

In your course, go to the Hotgrid item and trigger popup. The `a11y_alt_text` helper syntax shouldn't be visible within the popup display text and instead should just display '$5bn'.

Using the browser devtools, inspect '$5bn' and the helper should have split out the on screen text and a11y text e.g.
`<span aria-hidden="true">$5bn</span><span class="aria-label">five billion dollars</span>`