### PR TITLE
Fix: Responsive item width inconsistency (fixes #118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Enables the pop-ups to be cycled through endlessly using either the previous or 
 When set to `true`, hides the "previous" and "next" icons and progress indicator (e.g., "1/5") on the pop-up's toolbar. The default is `false`.
 
 ### \_columns (number):
-This value determines the number of columns within the grid. Any number of columns can be set however keep in mind the more columns there are the smaller the items will be.
+This value determines the number of columns within the grid. Any number of columns can be set however keep in mind the more columns there are the smaller the items will be. Mobile view defaults to a two column layout.
 
-**Hot Grid** has a dynamic layout system. If you have 5 items but set the columns to 3, **Hot Grid** will put 3 items in the first row and 2 on the second. The second row then will be automatically centred. This works with any amount of items and columns - i.e. that last row will always be centred for you.
+**Hot Grid** has a dynamic layout system. If you have 5 items but set the columns to 3, **Hot Grid** will put 3 items in the first row and 2 on the second. The second row will be automatically centred. This works with any amount of items and columns - i.e. that last row will always be centred.
 
 ### \_items (array):
 The items array contains the list of all the **Hot Grid** items. Each entry in the array should be an object, containing the following settings:

--- a/js/HotgridView.js
+++ b/js/HotgridView.js
@@ -25,7 +25,6 @@ class HotgridView extends ComponentView {
   }
 
   postRender() {
-    this.setUpColumns();
     this.$('.hotgrid__widget').imageready(this.setReadyStatus.bind(this));
 
     if (this.model.get('_setCompletionOn') === 'inview') {
@@ -34,15 +33,7 @@ class HotgridView extends ComponentView {
   }
 
   resizeControl() {
-    this.setUpColumns();
     this.render();
-  }
-
-  setUpColumns() {
-    const columns = this.model.get('_columns');
-    const columnWidth = columns && device.isScreenSizeMin('medium') ? 100 / columns : 100;
-
-    this.model.set('_columnWidth', columnWidth);
   }
 
   onItemClicked(e) {

--- a/templates/hotgrid.jsx
+++ b/templates/hotgrid.jsx
@@ -1,4 +1,5 @@
 import Adapt from 'core/js/adapt';
+import device from 'core/js/device';
 import React from 'react';
 import { templates, classes, compile } from 'core/js/reactHelpers';
 
@@ -8,10 +9,12 @@ export default function Hotgrid(props) {
 
   const {
     _items,
-    _columnWidth,
+    _columns,
     _isRound,
     onItemClicked
   } = props;
+
+  const hasColumnLayout = device.isScreenSizeMin('medium');
 
   const itemAriaLabel = (_index, _graphic, _isVisited) => {
     const arr = [];
@@ -38,13 +41,26 @@ export default function Hotgrid(props) {
 
       <templates.header {...props} />
 
-      <div className="component__widget hotgrid__widget">
+      <div
+        className={classes([
+          'component__widget',
+          'hotgrid__widget',
+          _columns && hasColumnLayout && 'has-column-layout'
+        ])}
+      >
 
         <div className="hotgrid__grid" role="list">
 
           {_items.map(({ _index, _graphic, _isVisited, _isActive }) =>
 
-            <div className="hotgrid__item" role="listitem" key={_index} style={{ width: _columnWidth + '%' }}>
+            <div
+              className="hotgrid__item"
+              role="listitem"
+              key={_index}
+              style={(_columns && hasColumnLayout) ?
+                { width: `${100 / _columns}%` } :
+                null}
+            >
 
               <button className={classes([
                 'hotgrid__item-btn',


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-hotgrid/issues/118
_Note, breakpoints were introduced after the issue was raised, so screen sizes mentioned in the issue have since changed._

The default `width: 50%` defined in the [CSS](https://github.com/cgkineo/adapt-hotgrid/blob/728b2a24ac85f082c56f524ffa03de3c166bee06/less/hotgrid.less#L10) was getting overwritten via the [JS inline style](https://github.com/cgkineo/adapt-hotgrid/blob/728b2a24ac85f082c56f524ffa03de3c166bee06/js/HotgridView.js#L43) regardless of screen size.

The inline style should only apply when screen size is `medium` and above, and inherit from the CSS otherwise. I've updated this for consistency with GMCQ which also uses [_columns](https://github.com/adaptlearning/adapt-contrib-gmcq/blob/53c5724364f3c416c0eae24ac8992104e05ea256/templates/gmcq.jsx#L58-L60).

## Testing PR
When reducing your browser width below `medium` (720px), Hotgrid should display as a two column layout. Above this screen width, the Hotgrid layout should reflect how many `_columns` have been defined on the component.