### PR TITLE
Fix: Add _classes to hotgrid__item (fixes #143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The main text for the popup that is shown when the item is selected by the learn
 Defines the alignment of the item image in the pop up. Left: Image aligned to the left of the text area. Top: Image aligned above the text area. Right: Image aligned to the right of the text area. Bottom: Image aligned below the text area. The default alignment is `right`.
 
 #### \_classes (string):
-CSS class name(s) to be applied to the item and item popup. Classes available by default are:
+CSS class name(s) to be applied to the popup item. Classes available by default are:
 * `"hide-desktop-image"` (hides the pop up image in desktop view)
 * `"hide-popup-image"` (hides the pop up image for all screen sizes)
 
@@ -80,6 +80,9 @@ The 'visited' state of the grid item image. This setting is optional and does no
 
 ##### alt (string):
 The alternative text for the item image. Assign [alt text](https://github.com/adaptlearning/adapt_framework/wiki/Providing-good-alt-text) to images that convey course content only. By default, the item is labelled by the `title` (if set), otherwise a generic 'Item 1, 2, 3 etc' label is applied, followed by the alternative text (if set).
+
+##### \_classes (string):
+CSS class name(s) to be applied to the grid item.
 
 #### \_itemGraphic (object):
 The itemGraphic object defines the image displayed in the popup that is shown when the item is selected by the learner. You only need to include this object if you want to display a different image in the popup. It contains the following settings:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The main text for the popup that is shown when the item is selected by the learn
 Defines the alignment of the item image in the pop up. Left: Image aligned to the left of the text area. Top: Image aligned above the text area. Right: Image aligned to the right of the text area. Bottom: Image aligned below the text area. The default alignment is `right`.
 
 #### \_classes (string):
-CSS class name(s) to be applied to the popup item. Classes available by default are:
+CSS class name(s) to be applied to the item button and popup item. Classes available by default are:
 * `"hide-desktop-image"` (hides the pop up image in desktop view)
 * `"hide-popup-image"` (hides the pop up image for all screen sizes)
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The main text for the popup that is shown when the item is selected by the learn
 Defines the alignment of the item image in the pop up. Left: Image aligned to the left of the text area. Top: Image aligned above the text area. Right: Image aligned to the right of the text area. Bottom: Image aligned below the text area. The default alignment is `right`.
 
 #### \_classes (string):
-CSS class name(s) to be applied to the item button and popup item. Classes available by default are:
+CSS class name(s) to be applied to the item and item popup. Classes available by default are:
 * `"hide-desktop-image"` (hides the pop up image in desktop view)
 * `"hide-popup-image"` (hides the pop up image for all screen sizes)
 

--- a/example.json
+++ b/example.json
@@ -28,7 +28,8 @@
                 "srcHover": "",
                 "srcVisited": "",
                 "alt": "",
-                "title": "Grid Title 1"
+                "title": "Grid Title 1",
+                "_classes": ""
             },
             "_itemGraphic": {
                 "src": "course/en/images/example.jpg",
@@ -46,7 +47,8 @@
                 "srcHover": "",
                 "srcVisited": "",
                 "alt": "",
-                "title": "Grid Title 2"
+                "title": "Grid Title 2",
+                "_classes": ""
             },
             "_itemGraphic": {
                 "src": "course/en/images/example.jpg",
@@ -64,7 +66,8 @@
                 "srcHover": "",
                 "srcVisited": "",
                 "alt": "",
-                "title": "Grid Title 3"
+                "title": "Grid Title 3",
+                "_classes": ""
             },
             "_itemGraphic": {
                 "src": "course/en/images/example.jpg",

--- a/templates/hotgrid.jsx
+++ b/templates/hotgrid.jsx
@@ -55,7 +55,10 @@ export default function Hotgrid(props) {
           {_items.map(({ _index, _graphic, _isVisited, _isActive, _classes }) =>
 
             <div
-              className="hotgrid__item"
+              className={classes([
+                'hotgrid__item',
+                _classes
+              ])}
               role="listitem"
               key={_index}
               style={(_columns && hasColumnLayout) ?
@@ -69,8 +72,7 @@ export default function Hotgrid(props) {
                 (_graphic.srcHover && _graphic.srcVisited) ? 'is-image' : 'has-css-states',
                 _isRound && 'is-round',
                 _isVisited && 'is-visited',
-                _isActive && 'is-active',
-                _classes
+                _isActive && 'is-active'
               ])}
               onClick={onItemClicked}
               data-index={_index}

--- a/templates/hotgrid.jsx
+++ b/templates/hotgrid.jsx
@@ -52,12 +52,12 @@ export default function Hotgrid(props) {
 
         <div className="hotgrid__grid" role="list">
 
-          {_items.map(({ _index, _graphic, _isVisited, _isActive, _classes }) =>
+          {_items.map(({ _index, _graphic, _isVisited, _isActive }) =>
 
             <div
               className={classes([
                 'hotgrid__item',
-                _classes
+                _graphic._classes
               ])}
               role="listitem"
               key={_index}

--- a/templates/hotgrid.jsx
+++ b/templates/hotgrid.jsx
@@ -52,7 +52,7 @@ export default function Hotgrid(props) {
 
         <div className="hotgrid__grid" role="list">
 
-          {_items.map(({ _index, _graphic, _isVisited, _isActive }) =>
+          {_items.map(({ _index, _graphic, _isVisited, _isActive, _classes }) =>
 
             <div
               className="hotgrid__item"
@@ -69,7 +69,8 @@ export default function Hotgrid(props) {
                 (_graphic.srcHover && _graphic.srcVisited) ? 'is-image' : 'has-css-states',
                 _isRound && 'is-round',
                 _isVisited && 'is-visited',
-                _isActive && 'is-active'
+                _isActive && 'is-active',
+                _classes
               ])}
               onClick={onItemClicked}
               data-index={_index}


### PR DESCRIPTION
Fix #143 

### Fix
* Adds the `_items._classes` to `.hotgrid__item` to assist with styling.
* Retains the custom class on the Hotgrid popups.
