### PR TITLE
Fix: Title is required to set notify popup dialog label (fixes #146)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -131,11 +131,11 @@
         "properties": {
           "title": {
             "type": "string",
-            "required": false,
+            "required": true,
             "default": "",
             "title": "Item Popup Title",
             "inputType": "Text",
-            "validators": [],
+            "validators": ["required"],
             "translatable": true
           },
           "body": {


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-hotgrid/issues/146

### Fix
* Set `title` as `required`. Without a title, the popup `dialog` won't be properly identified by assistive technologies.