### PR TITLE
Update: set item Title as required in component schema (fixes #146)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -131,11 +131,11 @@
         "properties": {
           "title": {
             "type": "string",
-            "required": false,
+            "required": true,
             "default": "",
             "title": "Item Popup Title",
             "inputType": "Text",
-            "validators": [],
+            "validators": ["required"],
             "translatable": true
           },
           "body": {

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -73,6 +73,10 @@
           "title": "Items",
           "items": {
             "type": "object",
+            "default": {},
+            "required": [
+              "title"
+            ],
             "properties": {
               "title": {
                 "type": "string",


### PR DESCRIPTION
This should have been implemented as part of [merged PR - Title is required to set notify popup dialog label](https://github.com/cgkineo/adapt-hotgrid/pull/147) for consistency with [Hotgraphic PR](https://github.com/adaptlearning/adapt-contrib-hotgraphic/pull/295). Branch re-opened.

Fixes https://github.com/cgkineo/adapt-hotgrid/issues/146