### PR TITLE
Fix: Set default for _imageAlignment for popup images (fixes #149)

### DIFF
--- a/templates/hotgridPopup.jsx
+++ b/templates/hotgridPopup.jsx
@@ -30,7 +30,7 @@ export default function HotgridPopup(props) {
           _isRound && 'is-round',
           _isVisited && 'is-visited',
           _isActive && 'is-active',
-          _imageAlignment ? `align-image-${_imageAlignment}` : 'align-image-right'
+          _graphic?.src && `align-image-${_imageAlignment || 'right'}`
         ])}
         key={index}
         data-index={index}

--- a/templates/hotgridPopup.jsx
+++ b/templates/hotgridPopup.jsx
@@ -30,7 +30,7 @@ export default function HotgridPopup(props) {
           _isRound && 'is-round',
           _isVisited && 'is-visited',
           _isActive && 'is-active',
-          _imageAlignment && `align-image-${_imageAlignment}`
+          _imageAlignment ? `align-image-${_imageAlignment}` : 'align-image-right'
         ])}
         key={index}
         data-index={index}
@@ -76,7 +76,7 @@ export default function HotgridPopup(props) {
             </div>
           </div>
 
-          {(_imageAlignment === 'right' || _imageAlignment === 'bottom') &&
+          {(_imageAlignment !== 'left' && _imageAlignment !== 'top') &&
           <templates.image {...(_itemGraphic.src ? _itemGraphic : _graphic)}
             classNamePrefixSeparator='__item-'
             classNamePrefixes={['component-item', 'hotgrid-popup']}


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-hotgrid/issues/149

### Fix
* Provide a default display of `_imageAlignment: "right"` in the instance `_imageAlignment` isn't set. The [schemas](https://github.com/cgkineo/adapt-hotgrid/blob/0ab9354d20091f5ebece3cdac9c648f37feb89c9/properties.schema#L153) already define a `default` value of `right`.

### Testing
1. In _component.json_, include a Hotgrid instance containing items with `_imageAlignment` `left`, `right` and blank values. For example:
```
   {
    "_id": "c-130",
    "_parentId": "b-120",
    "_type": "component",
    "_component": "hotgrid",
    "_classes": "",
    "_layout": "full",
    "title": "Hotgrid",
    "displayTitle": "Hotgrid",
    "body": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.",
    "instruction": "Select the images to find out more.",
    "_comment": "setCompletionOn = inview | allItems",
    "_setCompletionOn": "allItems",
    "_canCycleThroughPagination": false,
    "_hidePagination": false,
    "_columns": 3,
    "_isRound": false,
    "_showPlusIcon": false,
    "_items": [
        {
            "title": "Item Title 1",
            "body": "This is display text 1. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat.",
            "_imageAlignment": "right",
            "_comment": "Supported classes = 'hide-desktop-image' | 'hide-popup-image'. Additional classes can be used but they must be predefined in one of the Less files",
            "_classes": "",
            "_graphic": {
                "src": "course/en/images/menu-item.png",
                "srcHover": "",
                "srcVisited": "",
                "alt": "",
                "title": "Grid Title 1",
                "_classes": ""
            },
            "_itemGraphic": {
                "src": "course/en/images/menu-item.png",
                "alt": "",
                "attribution": "Copyright © 2019"
            }
        },
        {
            "title": "Item Title 2",
            "body": "This is display text 2 with a left aligned image.",
            "_imageAlignment": "left",
            "_classes": "",
            "_graphic": {
                "src": "course/en/images/menu-item.png",
                "srcHover": "",
                "srcVisited": "",
                "alt": "",
                "title": "Grid Title 2",
                "_classes": ""
            },
            "_itemGraphic": {
                "src": "course/en/images/menu-item.png",
                "alt": "",
                "attribution": ""
            }
        },
        {
            "title": "Item Title 3",
            "body": "This is display text 3.",
            "_imageAlignment": "",
            "_classes": "",
            "_graphic": {
                "src": "course/en/images/menu-item.png",
                "srcHover": "",
                "srcVisited": "",
                "alt": "",
                "title": "Grid Title 3",
                "_classes": ""
            },
            "_itemGraphic": {
                "src": "course/en/images/menu-item.png",
                "alt": "",
                "attribution": ""
            }
        }
    ],
    "_pageLevelProgress": {
        "_isEnabled": true
    }
  },
```
2. Review the Hotgrid in your course and ensure the item popup display matches the `_imageAlignment` value set. The blank value should default to `right` aligned display.