### PR TITLE
Fix: notify aria-labelledby element id (fixes #152)

### DIFF
--- a/templates/hotgridPopup.jsx
+++ b/templates/hotgridPopup.jsx
@@ -50,10 +50,8 @@ export default function HotgridPopup(props) {
 
               {title &&
               <div
-                className={classes([
-                  'hotgrid-popup__item-title',
-                  _isActive && 'notify-heading'
-                ])}
+                id={_isActive && 'notify-heading'}
+                className="hotgrid-popup__item-title"
                 role="heading"
                 aria-level={a11y.ariaLevel({ level: 'notify' })}
               >


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-hotgrid/issues/152

### Fix
* Changed 'notify-heading' to id from class such that the `aria-labelledby` on the dialog can find the element



