### PR TITLE
Fix: React HotgridPopup error for conditional `id` attribute

### DIFF
--- a/templates/hotgridPopup.jsx
+++ b/templates/hotgridPopup.jsx
@@ -50,7 +50,7 @@ export default function HotgridPopup(props) {
 
               {title &&
               <div
-                id={_isActive && 'notify-heading'}
+                id={_isActive ? 'notify-heading' : null}
                 className="hotgrid-popup__item-title"
                 role="heading"
                 aria-level={a11y.ariaLevel({ level: 'notify' })}


### PR DESCRIPTION
Fixes #154.

### Fix
* React HotgridPopup error for conditional `id` attribute.