### PR TITLE
Fix: Update "Item Popup Classes" schema description to remove align class (fix #156)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -162,7 +162,7 @@
             "title": "Item Popup Classes",
             "inputType": "Text",
             "validators": [],
-            "help": "Allows you to specify custom CSS classes to be applied to the popup item. Supported classes are 'align-image-left', 'hide-desktop-image', and 'hide-popup-image' which aligns the item image to the left, hides the pop up image in desktop view, and hides the pop up image for all screen sizes respectively."
+            "help": "Allows you to specify custom CSS classes to be applied to the popup item. 'hide-desktop-image' hides the pop up image in desktop view. 'hide-popup-image' hides the pop up image for all screen sizes."
           },
           "_graphic": {
             "type": "object",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -111,7 +111,7 @@
               "_classes": {
                 "type": "string",
                 "title": "Item Popup Classes",
-                "description": "Allows you to specify custom CSS classes to be applied to the popup item. Supported classes are 'hide-desktop-image' and 'hide-popup-image' which hides the pop up image in desktop view and hides the pop up image for all screen sizes respectively.",
+                "description": "Allows you to specify custom CSS classes to be applied to the popup item. 'hide-desktop-image' hides the pop up image in desktop view. 'hide-popup-image' hides the pop up image for all screen sizes.",
                 "default": ""
               },
               "_graphic": {

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -111,7 +111,7 @@
               "_classes": {
                 "type": "string",
                 "title": "Item Popup Classes",
-                "description": "Allows you to specify custom CSS classes to be applied to the popup item. Supported classes are 'align-image-left', 'hide-desktop-image', and 'hide-popup-image' which aligns the item image to the left, hides the pop up image in desktop view, and hides the pop up image for all screen sizes respectively.",
+                "description": "Allows you to specify custom CSS classes to be applied to the popup item. Supported classes are 'hide-desktop-image' and 'hide-popup-image' which hides the pop up image in desktop view and hides the pop up image for all screen sizes respectively.",
                 "default": ""
               },
               "_graphic": {


### PR DESCRIPTION
Fix #156 

### Fix
* Update "Item Popup Classes" schema description to remove reference to `align-image-left` class