### PR TITLE
New: Added support for new Vanilla button color mixins (fixes #145)

### DIFF
--- a/less/hotgrid.less
+++ b/less/hotgrid.less
@@ -1,3 +1,6 @@
+// fallback if Vanilla button styles aren't supported
+@item-color-style: none;
+
 .hotgrid {
   &__grid {
     display: flex;
@@ -109,6 +112,28 @@
 
   // Hotgrid item theme
   // --------------------------------------------------
+  // apply legacy styles if Vanilla button styles aren't supported
+  & when (@item-color-style = none) {
+    &__item-btn &__item-title,
+    &__item-btn &__item-icon {
+      background-color: @item-color;
+      color: @item-color-inverted;
+    }
+  
+    .no-touch &__item-btn:hover &__item-title,
+    .no-touch &__item-btn:not(.is-disabled):not(.is-locked):hover &__item-icon {
+      background-color: @item-color-hover;
+      color: @item-color-inverted-hover;
+      .transition(background-color @duration ease-in, color @duration ease-in;);
+    }
+  
+    &__item-btn.is-visited &__item-title,
+    &__item-btn.is-visited &__item-icon {
+      background-color: @visited;
+      color: @visited-inverted;
+    }
+  }
+
   & when (@item-color-style = filled) {
     &__item-btn &__item-title,
     &__item-btn &__item-icon {
@@ -150,6 +175,7 @@
       .item-color-outline-visited;
     }
   }
+
 
   // Hotgrid CSS border states
   // --------------------------------------------------

--- a/less/hotgrid.less
+++ b/less/hotgrid.less
@@ -109,23 +109,46 @@
 
   // Hotgrid item theme
   // --------------------------------------------------
-  &__item-btn &__item-title,
-  &__item-btn &__item-icon {
-    background-color: @item-color;
-    color: @item-color-inverted;
+  & when (@item-color-style = filled) {
+    &__item-btn &__item-title,
+    &__item-btn &__item-icon {
+      .item-color;
+    }
+  
+    .no-touch &__item-btn:hover &__item-title,
+    .no-touch &__item-btn:not(.is-disabled):not(.is-locked):hover &__item-icon {
+      .item-color-hover;
+    }
+
+    html:not(.a11y-disable-focusoutline) &:focus-visible {
+      .item-color-focus;
+    }
+  
+    &__item-btn.is-visited &__item-title,
+    &__item-btn.is-visited &__item-icon {
+      .item-color-visited;
+    }
   }
 
-  .no-touch &__item-btn:hover &__item-title,
-  .no-touch &__item-btn:not(.is-disabled):not(.is-locked):hover &__item-icon {
-    background-color: @item-color-hover;
-    color: @item-color-inverted-hover;
-    .transition(background-color @duration ease-in, color @duration ease-in;);
-  }
+  & when (@item-color-style = outline) {
+    &__item-btn &__item-title,
+    &__item-btn &__item-icon {
+      .item-color-outline;
+    }
+  
+    .no-touch &__item-btn:hover &__item-title,
+    .no-touch &__item-btn:not(.is-disabled):not(.is-locked):hover &__item-icon {
+      .item-color-outline-hover;
+    }
 
-  &__item-btn.is-visited &__item-title,
-  &__item-btn.is-visited &__item-icon {
-    background-color: @visited;
-    color: @visited-inverted;
+    html:not(.a11y-disable-focusoutline) &:focus-visible {
+      .item-color-outline-focus;
+    }
+  
+    &__item-btn.is-visited &__item-title,
+    &__item-btn.is-visited &__item-icon {
+      .item-color-outline-visited;
+    }
   }
 
   // Hotgrid CSS border states


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-hotgrid/issues/145

### New
* Added support for new [Vanilla button color mixins](https://github.com/adaptlearning/adapt-contrib-vanilla/pull/490 ). Default button style set to `filled` to mimic current Vanilla and `outline` as optional style. The implementation allows for additional styles to be created for custom themes.
* Focus state added.
* Legacy support added to prevent breaking change. AFAIK, this is the first plugin to be updated to support the new Vanilla buttons. Are we happy to apply the same fallback implementation for other plugins?

### Testing legacy support
1. Install Vanilla master.
2. There should be no change in styling.

### Testing new Vanilla buttons
1. Install Vanilla [PR](https://github.com/adaptlearning/adapt-contrib-vanilla/tree/issue/469).
2. Hotgrid item button style can be changed via the `@item-color-style` variable in [less/_defaults/_btn-style.less](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/issue/469/less/_defaults/_btn-style.less). Test both `filled` and `outline` styles.
3. Check all states styles apply (default, hover, focus and visited).


