### PR TITLE
Chore: Use shared workflow files (fix #177)

### DIFF
--- a/.github/workflows/addtomainproject.yml
+++ b/.github/workflows/addtomainproject.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   add-to-project:
-    uses: cgkineo/.github/.github/workflows/addtomainproject.yml@main
+    uses: cgkineo/.github/.github/workflows/addtomainproject.yml@master
     secrets: inherit

--- a/.github/workflows/addtomainproject.yml
+++ b/.github/workflows/addtomainproject.yml
@@ -1,5 +1,4 @@
 name: Add to main project
-
 on:
   issues:
     types:
@@ -7,7 +6,6 @@ on:
   pull_request:
     types:
       - opened
-
 jobs:
   add-to-project:
     uses: cgkineo/.github/.github/workflows/addtomainproject.yml@master

--- a/.github/workflows/addtomainproject.yml
+++ b/.github/workflows/addtomainproject.yml
@@ -10,10 +10,5 @@ on:
 
 jobs:
   add-to-project:
-    name: Add to main project
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/add-to-project@v0.1.0
-        with:
-          project-url: https://github.com/orgs/cgkineo/projects/3/views/1
-          github-token: ${{ secrets.ADDTOPROJECT_TOKEN }}
+    uses: cgkineo/cgkineo/.github/workflows/addtomainproject.yml@main
+    secrets: inherit

--- a/.github/workflows/addtomainproject.yml
+++ b/.github/workflows/addtomainproject.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   add-to-project:
-    uses: cgkineo/cgkineo/.github/workflows/addtomainproject.yml@main
+    uses: cgkineo/.github/.github/workflows/addtomainproject.yml@main
     secrets: inherit

--- a/.github/workflows/addtomainproject.yml
+++ b/.github/workflows/addtomainproject.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     types:
       - opened
+  workflow_dispatch:
 jobs:
   add-to-project:
     uses: cgkineo/.github/.github/workflows/addtomainproject.yml@master

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,25 +1,11 @@
 name: Release
+
 on:
   push:
     branches:
       - master
+
 jobs:
   release:
-    name: Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-      - name: Install dependencies
-        run: npm ci
-      - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+    uses: cgkineo/cgkineo/.github/workflows/release.yml@main
+    secrets: inherit

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: cgkineo/.github/.github/workflows/release.yml@main
+    uses: cgkineo/.github/.github/workflows/releases.yml@main
     secrets: inherit

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: cgkineo/cgkineo/.github/workflows/release.yml@main
+    uses: cgkineo/.github/.github/workflows/release.yml@main
     secrets: inherit

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: cgkineo/.github/.github/workflows/releases.yml@main
+    uses: cgkineo/.github/.github/workflows/releases.yml@master
     secrets: inherit

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,10 +1,8 @@
 name: Release
-
 on:
   push:
     branches:
       - master
-
 jobs:
   release:
     uses: cgkineo/.github/.github/workflows/releases.yml@master

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 jobs:
   release:
     uses: cgkineo/.github/.github/workflows/releases.yml@master


### PR DESCRIPTION
Fix #177

### Chore

- Update workflows to use shared versions from organization
- Workflows can be manually ran in GitHub due to including the `workflow_dispatch` event