### PR TITLE
Update: Rework popup aria labels for Previous and Next (fixes #191)

### DIFF
--- a/js/HotgridPopupView.js
+++ b/js/HotgridPopupView.js
@@ -63,41 +63,37 @@ class HotgridPopupView extends Backbone.View {
     const totalItems = this.model.getChildren().length;
     const canCycleThroughPagination = this.model.get('_canCycleThroughPagination');
 
-    const isAtStart = index === 0;
-    const isAtEnd = index === totalItems - 1;
+    // When looping is enabled the buttons never disable and always wrap,
+    // so the active item is never treated as the start or end.
+    const isAtStart = !canCycleThroughPagination && index === 0;
+    const isAtEnd = !canCycleThroughPagination && index === totalItems - 1;
 
     const globals = Adapt.course.get('_globals');
     const hotgridGlobals = globals._components._hotgrid;
 
-    let prevTitle = isAtStart ? '' : this.model.getItem(index - 1).get('title');
-    let nextTitle = isAtEnd ? '' : this.model.getItem(index + 1).get('title');
+    const prevIndex = (index - 1 + totalItems) % totalItems;
+    const nextIndex = (index + 1) % totalItems;
 
-    let backItem = isAtStart ? null : index;
-    let nextItem = isAtEnd ? null : index + 2;
+    const prevTitle = isAtStart ? '' : this.model.getItem(prevIndex).get('title');
+    const nextTitle = isAtEnd ? '' : this.model.getItem(nextIndex).get('title');
 
-    if (canCycleThroughPagination) {
-      if (isAtStart) {
-        prevTitle = this.model.getItem(totalItems - 1).get('title');
-        backItem = totalItems;
-      }
-      if (isAtEnd) {
-        nextTitle = this.model.getItem(0).get('title');
-        nextItem = 1;
-      }
-    }
+    const backItem = isAtStart ? null : prevIndex + 1;
+    const nextItem = isAtEnd ? null : nextIndex + 1;
 
     const backLabel = compile(hotgridGlobals.previous, {
       _globals: globals,
       title: prevTitle,
       itemNumber: backItem,
-      totalItems
+      totalItems,
+      isAtStart
     });
 
     const nextLabel = compile(hotgridGlobals.next, {
       _globals: globals,
       title: nextTitle,
       itemNumber: nextItem,
-      totalItems
+      totalItems,
+      isAtEnd
     });
 
     this.model.set('backLabel', backLabel);
@@ -110,9 +106,9 @@ class HotgridPopupView extends Backbone.View {
     const template = pagingTemplate || '{{itemNumber}} / {{totalItems}}';
     const itemNumber = this.model.getActiveItem().get('_index') + 1;
     const totalItems = this.model.getChildren().length;
-    const itemCount = compile(template, { itemNumber, totalItems });
+    const popupCount = compile(template, { itemNumber, totalItems });
 
-    this.model.set('itemCount', itemCount);
+    this.model.set('popupCount', popupCount);
   }
 
   onItemsActiveChange(item, _isActive) {

--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -286,3 +286,66 @@ describe('Hot Grid - v4.4.1 to v4.4.2', async () => {
   });
 });
 
+describe('Hot Grid - @@CURRENT_VERSION to @@RELEASE_VERSION', async () => {
+  let course, courseHotgridGlobals;
+  const originalPrevious = '{{#if title}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}}';
+  const updatedPrevious = '{{#if isAtStart}}{{_globals._accessibility._ariaLabels.previous}}{{else}}{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}';
+  const originalNext = '{{#if title}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}}';
+  const updatedNext = '{{#if isAtEnd}}{{_globals._accessibility._ariaLabels.next}}{{else}}{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}';
+
+  whereFromPlugin('Hot Grid - from @@CURRENT_VERSION', { name: 'adapt-hotgrid', version: '<@@RELEASE_VERSION' });
+
+  whereContent('Hot Grid - where hotgrid', async content => {
+    return content.some(({ _component }) => _component === 'hotgrid');
+  });
+
+  mutateContent('Hot Grid - update globals previous attribute', async content => {
+    course = getCourse();
+    courseHotgridGlobals = _.get(course, '_globals._components._hotgrid');
+    if (courseHotgridGlobals?.previous === originalPrevious) courseHotgridGlobals.previous = updatedPrevious;
+    return true;
+  });
+
+  mutateContent('Hot Grid - update globals next attribute', async content => {
+    if (courseHotgridGlobals?.next === originalNext) courseHotgridGlobals.next = updatedNext;
+    return true;
+  });
+
+  checkContent('Hot Grid - check globals previous attribute', async content => {
+    if (courseHotgridGlobals?.previous === originalPrevious) throw new Error('Hot Grid - globals previous not updated');
+    return true;
+  });
+
+  checkContent('Hot Grid - check globals next attribute', async content => {
+    if (courseHotgridGlobals?.next === originalNext) throw new Error('Hot Grid - globals next not updated');
+    return true;
+  });
+
+  updatePlugin('Hot Grid - update to @@RELEASE_VERSION', { name: 'adapt-hotgrid', version: '@@RELEASE_VERSION', framework: '>=5.46.4' });
+
+  testSuccessWhere('hotgrid components with original globals', {
+    fromPlugins: [{ name: 'adapt-hotgrid', version: '@@CURRENT_VERSION' }],
+    content: [
+      { _type: 'course', _globals: { _components: { _hotgrid: { previous: originalPrevious, next: originalNext } } } },
+      { _id: 'c-100', _component: 'hotgrid' }
+    ]
+  });
+
+  testSuccessWhere('hotgrid components with empty globals', {
+    fromPlugins: [{ name: 'adapt-hotgrid', version: '@@CURRENT_VERSION' }],
+    content: [
+      { _type: 'course' },
+      { _id: 'c-100', _component: 'hotgrid' }
+    ]
+  });
+
+  testStopWhere('already at @@RELEASE_VERSION', {
+    fromPlugins: [{ name: 'adapt-hotgrid', version: '@@RELEASE_VERSION' }]
+  });
+
+  testStopWhere('no hotgrid components', {
+    fromPlugins: [{ name: 'adapt-hotgrid', version: '@@CURRENT_VERSION' }],
+    content: [{ _component: 'other' }]
+  });
+});
+

--- a/properties.schema
+++ b/properties.schema
@@ -23,7 +23,7 @@
     "previous": {
       "type": "string",
       "title": "Hotgrid popup previous label",
-      "default": "{{#if title}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}}",
+      "default": "{{#if isAtStart}}{{_globals._accessibility._ariaLabels.previous}}{{else}}{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
       "inputType": "Text",
       "translatable": true,
       "help": "This is the aria label for the previous button in the popup."
@@ -31,7 +31,7 @@
     "next": {
       "type": "string",
       "title": "Hotgrid popup next label",
-      "default": "{{#if title}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}}",
+      "default": "{{#if isAtEnd}}{{_globals._accessibility._ariaLabels.next}}{{else}}{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
       "inputType": "Text",
       "translatable": true,
       "help": "This is the aria label for the next button in the popup."

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -36,7 +36,7 @@
                       "type": "string",
                       "title": "Popup previous label",
                       "description": "This is the aria label for the previous button in the popup.",
-                      "default": "{{#if title}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}}",
+                      "default": "{{#if isAtStart}}{{_globals._accessibility._ariaLabels.previous}}{{else}}{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
                       "_adapt": {
                         "translatable": true
                       }
@@ -45,7 +45,7 @@
                       "type": "string",
                       "title": "Popup next label",
                       "description": "This is the aria label for the next button in the popup.",
-                      "default": "{{#if title}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}}",
+                      "default": "{{#if isAtEnd}}{{_globals._accessibility._ariaLabels.next}}{{else}}{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
                       "_adapt": {
                         "translatable": true
                       }

--- a/templates/hotgridPopupToolbar.jsx
+++ b/templates/hotgridPopupToolbar.jsx
@@ -11,7 +11,7 @@ export default function HotgridPopupToolbar(props) {
     onControlClick,
     shouldEnableBack,
     shouldEnableNext,
-    itemCount,
+    popupCount,
     backLabel,
     nextLabel,
     _hidePagination
@@ -46,7 +46,7 @@ export default function HotgridPopupToolbar(props) {
 
         <div
           className="hotgrid-popup__count"
-          dangerouslySetInnerHTML={{ __html: itemCount }}
+          dangerouslySetInnerHTML={{ __html: popupCount }}
           aria-hidden="true"
         />
 


### PR DESCRIPTION
Fixes #191

### Update
* Popup Previous/Next aria labels now utilize `isAtStart`/`isAtEnd` instead of the presence of an item title. So a middle item with an empty title still announces its position (e.g. "Previous (item 2 of 3)") instead of falling back to a bare "Previous"/"Next".
* When looping (`_canCycleThroughPagination`), `isAtStart`/`isAtEnd` are forced `false`. The buttons never disable and always wrap, so the active item is never treated as the start or end and the item count is always announced.
* Renamed the popup count model attribute `itemCount` to `popupCount` to match adapt-contrib-hotgraphic.
* Schemas updated with the new defaults.
* Aligns the Hot Grid popup with Hot Graphic and adapt-contrib-narrative. The `_itemGraphic` feature and styling differences remain intentional.
* Added a migration to update the `previous`/`next` globals on existing courses, but only where the value still equals the old default. Author customizations are preserved.

### Testing
1. Hot Grid popup, looping off:
   - First item: Previous = plain "Previous" (disabled); Next = "item 2 of N".
   - Last item: Next = plain "Next" (disabled); Previous = "item N-1 of N".
2. Clear a middle item's `title`: Previous/Next still announce "(item N of M)" rather than the bare label.
3. Enable `_canCycleThroughPagination`: buttons never disable, wrap correctly, and always announce the item count (including at the first/last item).
4. Verify with a screen reader (VoiceOver/NVDA).
5. Migration: `grunt migration:test` passes (19/19).

Posted via collaboration with Claude Code