### PR TITLE
Fix: instruction migration check preserves custom values (fixes #193)

### DIFF
--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -223,18 +223,19 @@ describe('Hot Grid - v4.3.13 to v4.3.14', async () => {
   });
   checkContent('Hot Grid - check instruction attribute', async content => {
     const isValid = hotgrids.every(hotgrid =>
-      hotgrid.instruction === 'Select the images to find out more.'
+      hotgrid.instruction !== ''
     );
     if (!isValid) throw new Error('Hot Grid - instruction attribute not set to default value');
     return true;
   });
   updatePlugin('Hot Grid - update to v4.3.14', { name: 'adapt-hotgrid', version: '4.3.14', framework: '>=5.31.11' });
 
-  testSuccessWhere('correct version with hotgrid components with empty instruction', {
+  testSuccessWhere('correct version with hotgrid components with empty/custom instruction', {
     fromPlugins: [{ name: 'adapt-hotgrid', version: '4.3.13' }],
     content: [
       { _id: 'c-100', _component: 'hotgrid', instruction: '' },
-      { _id: 'c-105', _component: 'hotgrid', instruction: '' }
+      { _id: 'c-105', _component: 'hotgrid', instruction: '' },
+      { _id: 'c-110', _component: 'hotgrid', instruction: 'Click each image for more information' }
     ]
   });
 


### PR DESCRIPTION
Fixes #193

### Fix
- The `v4.3.13 > v4.3.14` migration's `mutateContent` only sets the default `instruction` when it is empty (correctly preserving custom values), but the matching `checkContent` required *every* hotgrid's `instruction` to equal the default string. A hotgrid with a custom `instruction` failed the check, so the migration threw — and because that throw aborts the migration run, it could also block other plugins' migrations in the same pass.
- Changed the check to assert the mutate's actual intent (no `instruction` left empty: `instruction !== ''`) rather than equality with the default.
- Extended the `testSuccessWhere` fixture with a custom-instruction component to cover the case.

### Testing
1. `grunt migration:test --file=adapt-hotgrid`
2. All 27 scenarios pass, including a hotgrid with a custom `instruction` (which failed before the fix).
