### PR TITLE
Fix: instruction migration check fails on custom values (fixes #193)

### DIFF
--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -223,7 +223,7 @@ describe('Hot Grid - v4.3.13 to v4.3.14', async () => {
   });
   checkContent('Hot Grid - check instruction attribute', async content => {
     const isValid = hotgrids.every(hotgrid =>
-      hotgrid.instruction === 'Select the images to find out more.'
+      hotgrid.instruction !== ''
     );
     if (!isValid) throw new Error('Hot Grid - instruction attribute not set to default value');
     return true;


### PR DESCRIPTION
### Fixes #193

### Fix
- The `v4.3.13 → v4.3.14` instruction migration's `checkContent` required **every** hotgrid's `instruction` to equal the default string (`"Select the images to find out more."`). The paired `mutateContent` only sets the default when `instruction` is empty (correctly preserving custom values), so any hotgrid with a custom `instruction` failed the check and the migration threw — aborting the whole migration pass (and, on import, rolling back unrelated plugins migrating in the same run).
- The check now asserts the mutate's actual intent — that no `instruction` is left empty — rather than equality with the default:

  ```js
  const isValid = hotgrids.every(hotgrid => hotgrid.instruction !== '');
  ```

### Testing
- Reproduced the failure with `adapt-migrations` against content containing a custom `instruction` (`mutate success` → `check errored`, matching the reported import error).
- Verified the fix: empty instructions are defaulted, custom values preserved, no throw.
- All hotgrid migration self-tests (`testSuccessWhere`/`testStopWhere`) pass.